### PR TITLE
Add dist and freedoom docs

### DIFF
--- a/dist/COPYING.CC0
+++ b/dist/COPYING.CC0
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/dist/README
+++ b/dist/README
@@ -1,0 +1,4 @@
+This directory contains some files that should be useful for system
+installations on Unix-like operating systems, including desktop
+entries, AppData XML files, and a shell script to run Blasphemer in a
+simple manner.

--- a/dist/blasphemer
+++ b/dist/blasphemer
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: CC0-1.0
+
+# These ports should be ordered by ease-of-use, of which menu
+# simplicity and support for high-resolution take high priority.
+
+# "doom" is Debian’s generic name for their alternatives system.
+
+PORTS="eternity gzdoom crispy-heretic dsda-doom vavoom"
+
+# Just a single argument starting the command is allowed, -p, in order
+# to explicitly set a port on the command line. -- is also supported
+# so that -p can be instead sent directly to the port’s argument list.
+
+if [ $# -gt 0 ]; then
+    if [ "$1" = "-p" ]; then
+        DOOMPORT="$2"
+        shift; shift
+    elif [ "$1" = "--" ]; then
+        shift
+    fi
+fi
+
+case "$(basename "$0")" in
+    blasphdm)
+        IWAD=BlasphDM.wad
+        ;;
+    blasphemer)
+        IWAD=blasphem.wad
+        ;;
+esac
+
+if [ -z "$DOOMWADPATH" ]; then
+    # Support installations of Blasphemer to the home directory using
+    # the XDG spec.  Makes this complicated, but let’s do it right.
+    if [ -z "$XDG_DATA_HOME" ]; then
+        if [ -z "$HOME" ]; then
+            HOME=/
+        fi
+        XDG_PATH="$HOME"/.local/share/games/doom
+    else
+        XDG_PATH="$XDG_DATA_HOME"/games/doom
+    fi
+
+    PATHS=(
+        "$XDG_PATH"
+        /usr/local/share/games/doom
+        /usr/local/share/doom
+        /usr/share/games/doom
+        /usr/share/doom
+    )
+    export DOOMWADPATH="$(echo "${PATHS[@]}" | tr ' ' :)"
+fi
+
+if [ -z "$DOOMPORT" ] && [ -h "$HOME"/.doomport ]; then
+    if [ -f "$(readlink -f "$HOME"/.doomport)" ] \
+        && [ -x "$(readlink -f "$HOME"/.doomport)" ]; then
+        DOOMPORT="$(readlink -f "$HOME"/.doomport)"
+    fi
+fi
+
+if [ "$DOOMPORT" ]; then
+    exec "$DOOMPORT" -iwad "$IWAD" "$@"
+fi
+
+dirpath=$(eval echo "\${PATH}" 2>/dev/null | tr : ' ')
+
+for port in $PORTS; do
+    for dir in $dirpath; do
+        for file in "$dir"/"$port"; do
+            if [ -f "$file" ] && [ -x "$file" ]; then
+                exec "$file" -iwad "$IWAD" "$@"
+            fi
+        done
+    done
+done
+
+# If we’ve reached this far, no engine was successfully executed.
+# print message to stderr and exit with a status of 1.
+
+cat <<EOF >&2
+$(basename "$0") could not locate nor launch a Doom engine.  Most
+likely, you simply need to install one, check your distribution
+package repositories for names such as "dsda-doom" or "crispy-heretic" or
+seek out one and install it manually.
+
+If you believe you already have one, you may just need to modify your
+PATH environment variable to include it, or set up the $HOME/.doomport
+symbolic link to point directly to the engine of your choice.
+EOF
+exit 1

--- a/dist/blasphemer.adoc
+++ b/dist/blasphemer.adoc
@@ -1,0 +1,47 @@
+= blasphemer(6)
+// SPDX-License-Identifier: CC0-1.0
+:doctype: manpage
+
+== NAME
+blasphemer - Automatically launch Blasphemer with an engine
+
+== SYNOPSIS
+*blasphemer* [_-p_ _DOOMPORT_|_--_] [_ARGS_]
+
+== DESCRIPTION
+Blasphemer is a project to create a complete free-content game based on
+the _Heretic_ engine (often called “source ports” or simply “ports”),
+which itself is free software.  In addition, it maintains
+compatibility with _Heretic_ itself and is capable of playing the wide
+variety of modifications (“mods”) that have been released by an
+active community since 1994.
+
+This command is a simple shell script to assist in running Blasphemer,
+which is not a game engine itself nor part of any engine project, but
+playing Blasphemer should remain simple.  The script tries to
+automatically select an engine based on a hard-coded list, but three
+overrides are available, in order of precedence: command-line
+argument, environment variable, and a +$HOME/.doomport+ symbolic link.
+Passing _-p DOOMPORT_ runs Blasphemer using the _DOOMPORT_ specified.
+Setting the _DOOMPORT_ environment variable is similar, running the
+engine specified in the variable.  An additional permanent setting is
+via the +$HOME/.doomport+ symbolic link, which may point to an
+executable to run.
+
+Additional arguments passed to the program, or after specifying _--_
+as the first option, will be passed to the engine being called.  This
+can allow you to use options such as _-file_ to load mods or anything
+else available with the engine of choice.
+
+== COPYRIGHT
+Blasphemer is licensed under a permissive three-clause BSD license.  For
+details, see the source tree or the +COPYING+/+COPYRIGHT+ file that
+was installed by distribution packaging.
+
+This manual page and the launcher script are both placed under the
+public domain.
+
+== SEE ALSO
+chocolate-doom(6), crispy-doom(6), prboom-plus(6)
+
+https://doomwiki.org/wiki/Parameter

--- a/dist/io.github.Catoptromancy.BlasphDM.desktop
+++ b/dist/io.github.Catoptromancy.BlasphDM.desktop
@@ -1,0 +1,16 @@
+[Desktop Entry]
+Name=BlasphDM
+Comment=Fight friends and enemies in competitive deathmatch
+Comment[he]=הילחם בחברים ובאויבים בקרבות מיתה תחרותיים
+Comment[es]=Lucha contra amigos y enemigos en un deathmatch competitivo
+Comment[fr]=Affrontez vos amis et vos ennemis dans un match à mort compétitif
+GenericName=First Person Shooter Game
+GenericName[he]=משחק יריות בגוף ראשון
+GenericName[es]=Juego de disparos en primera persona
+GenericName[fr]=Jeu de tir à la première personne
+Type=Application
+PrefersNonDefaultGPU=true
+Icon=io.github.Catoptromancy.BlasphDM
+Keywords=first;person;shooter;doom;freedoom;heretic;blasphemer
+Categories=Game;ActionGame;
+Exec=blasphdm

--- a/dist/io.github.Catoptromancy.BlasphDM.metainfo.xml
+++ b/dist/io.github.Catoptromancy.BlasphDM.metainfo.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
+
+<component type="desktop">
+  <id>io.github.Catoptromancy.BlasphDM</id>
+  <name>BlasphDM</name>
+  <summary>Deathmatch game based on the Doom engine</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>BSD-3-Clause</project_license>
+  <developer_name>Blasphemer Project</developer_name>
+  <url type="homepage">https://www.doomworld.com/vb/freedoom/70732-blasphemer-discussion/</url>
+  <url type="bugtracker">https://github.com/Catoptromancy/blasphemer/issues</url>
+  <description>
+    <p>
+      BlasphDM is a fast-paced set of levels designed for multiplayer
+      deathmatches, part of the Blasphemer project.  Challenge your
+      friends to the most torturous test of their abilities as you
+      navigate through 32 levels stalking and hunting them.
+    </p>
+    <p>
+      The Blasphemer project aims to produce three base-game data files
+      (IWADs) for Heretic-compatible engines.  With it comes the
+      capability to also play the wide range of mods created for Heretic
+      by a vibrant community.  BlasphDM is fully compatible with Heretic
+      mods.
+    </p>
+  </description>
+  <categories>
+    <category>Game</category>
+    <category>ActionGame</category>
+  </categories>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">intense</content_attribute>
+    <content_attribute id="violence-fantasy">intense</content_attribute>
+    <content_attribute id="violence-bloodshed">intense</content_attribute>
+    <content_attribute id="violence-desecration">mild</content_attribute>
+    <content_attribute id="language-profanity">mild</content_attribute>
+    <content_attribute id="language-humor">mild</content_attribute>
+  </content_rating>
+  <!-- Note that some screenshots are PNG and others are JPG. These URLs should
+       not change, but double check them each release. -->
+  <screenshots>
+    <screenshot type="default">
+      <image>http://www.jeshimoth.com/blas014_02.png</image>
+      <caption>Blasphemer Screenshot</caption>
+    </screenshot>
+    <screenshot>
+      <image>http://www.jeshimoth.com/blas01301.png</image>
+      <caption>Blasphemer Screenshot</caption>
+    </screenshot>
+    <screenshot>
+      <image>http://www.jeshimoth.com/blas01302.png</image>
+      <caption>Blasphemer Screenshot</caption>
+    </screenshot>
+    <screenshot>
+      <image>http://www.jeshimoth.com/blas01303.png</image>
+      <caption>Blasphemer Screenshot</caption>
+    </screenshot>
+    <screenshot>
+      <image>http://www.jeshimoth.com/blas01304.png</image>
+      <caption>Blasphemer Screenshot</caption>
+    </screenshot>
+    <screenshot>
+      <image>http://www.jeshimoth.com/blas01305.png</image>
+      <caption>Blasphemer Screenshot</caption>
+    </screenshot>
+    <screenshot>
+      <image>http://www.jeshimoth.com/blas01306.png</image>
+      <caption>Blasphemer Screenshot</caption>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="0.1.9-fork-002" date="2024-05-07"></release>
+  </releases>
+</component>

--- a/dist/io.github.Catoptromancy.Blasphemer.desktop
+++ b/dist/io.github.Catoptromancy.Blasphemer.desktop
@@ -1,0 +1,16 @@
+[Desktop Entry]
+Name=Blasphemer
+Comment=Battle monsters in five 9-level episodes
+Comment[he]=הילחם במפלצות בארבעה פרקים בעלי 9 שלבים
+Comment[es]=Pelea contra monstruos en cuatro episodios de 9 niveles
+Comment[fr]=Affrontez des monstres dans quatre épisodes de 9 niveaux
+GenericName=First Person Shooter Game
+GenericName[he]=משחק יריות בגוף ראשון
+GenericName[es]=Juego de disparos en primera persona
+GenericName[fr]=Jeu de tir à la première personne
+Type=Application
+PrefersNonDefaultGPU=true
+Icon=io.github.Catoptromancy.Blasphemer
+Keywords=first;person;shooter;doom;freedoom;heretic;blasphemer
+Categories=Game;ActionGame;
+Exec=blasphemer

--- a/dist/io.github.Catoptromancy.Blasphemer.metainfo.xml
+++ b/dist/io.github.Catoptromancy.Blasphemer.metainfo.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
+
+<component type="desktop">
+  <id>io.github.Catoptromancy.Blasphemer</id>
+  <name>Blasphemer</name>
+  <summary>First-person shooter based on the Doom engine</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>BSD-3-Clause</project_license>
+  <developer_name>Blasphemer Project</developer_name>
+  <url type="homepage">https://www.doomworld.com/vb/freedoom/70732-blasphemer-discussion/</url>
+  <url type="bugtracker">https://github.com/Catoptromancy/blasphemer/issues</url>
+  <description>
+    <p>
+      Blasphemer contains five episodes, nine levels each, to
+      provide a smoothly-paced first person action game.  In it is a
+      wide variety of mazes and enemies to fight and challenge your
+      reflexes.
+    </p>
+    <p>
+      The Blasphemer project aims to produce three base-game data files
+      (IWADs) for Heretic-compatible engines.  With it comes the
+      capability to also play the wide range of mods created for Heretic
+      by a vibrant community.  Blasphemer is fully compatible
+      with Heretic: Shadow of The Serpent Riders mods.
+    </p>
+  </description>
+  <categories>
+    <category>Game</category>
+    <category>ActionGame</category>
+  </categories>
+  <content_rating type="oars-1.1">
+    <content_attribute id="violence-cartoon">intense</content_attribute>
+    <content_attribute id="violence-fantasy">intense</content_attribute>
+    <content_attribute id="violence-bloodshed">intense</content_attribute>
+    <content_attribute id="violence-desecration">mild</content_attribute>
+    <content_attribute id="language-profanity">mild</content_attribute>
+    <content_attribute id="language-humor">mild</content_attribute>
+  </content_rating>
+  <!-- Note that some screenshots are PNG and others are JPG. These URLs should
+       not change, but double check them each release. -->
+  <screenshots>
+    <screenshot type="default">
+      <image>http://www.jeshimoth.com/blas014_02.png</image>
+      <caption>Blasphemer Screenshot</caption>
+    </screenshot>
+    <screenshot>
+      <image>http://www.jeshimoth.com/blas01301.png</image>
+      <caption>Blasphemer Screenshot</caption>
+    </screenshot>
+    <screenshot>
+      <image>http://www.jeshimoth.com/blas01302.png</image>
+      <caption>Blasphemer Screenshot</caption>
+    </screenshot>
+    <screenshot>
+      <image>http://www.jeshimoth.com/blas01303.png</image>
+      <caption>Blasphemer Screenshot</caption>
+    </screenshot>
+    <screenshot>
+      <image>http://www.jeshimoth.com/blas01304.png</image>
+      <caption>Blasphemer Screenshot</caption>
+    </screenshot>
+    <screenshot>
+      <image>http://www.jeshimoth.com/blas01305.png</image>
+      <caption>Blasphemer Screenshot</caption>
+    </screenshot>
+    <screenshot>
+      <image>http://www.jeshimoth.com/blas01306.png</image>
+      <caption>Blasphemer Screenshot</caption>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="0.1.9-fork-002" date="2024-05-07"></release>
+  </releases>
+</component>

--- a/docs/freedoom-docs/COPYING.adoc
+++ b/docs/freedoom-docs/COPYING.adoc
@@ -1,0 +1,30 @@
+Copyright © 2001-2024
+Contributors to the Freedoom project.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of the Freedoom project nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS
+IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+For a list of contributors to the Freedoom project, see the file
+CREDITS.

--- a/docs/freedoom-docs/CREDITS
+++ b/docs/freedoom-docs/CREDITS
@@ -1,0 +1,1037 @@
+[Some of the entries on this file are decades old. If you have contributed to Freedoom and want to update anything on here, please post an issue or reach out to any active maintainer!]
+
+[See the CREDITS-LEVELS file for specific level authors and titles.]
+[See the CREDITS-MUSIC  file for specific track authors and titles.]
+
+N: Colin Phipps
+S: cph
+E: cph@cph.demon.co.uk
+W: http://www.cph.demon.co.uk/
+D: binary lumps (playpal, colormap etc)
+
+N: Julian Aubourg
+S: Julian
+E: julian@doomworld.com
+D: sprites, stories, textures
+
+S: Captain Mellow
+E: captainmellow@yahoo.com
+D: textures, music
+
+N: Nick Baker
+S: NightMare
+E: nick@frad.org
+D: textures
+
+S: Tarin
+E: tarin@paci-fist.net
+D: textures, sprites, website design, levels
+
+N: Andrew Stine
+S: Linguica
+E: linguica@doomworld.com
+D: textures
+
+N: Emmanuel Rousseau
+S: GodCells
+E: Emmanuel_Rousseau@uqac.ca
+D: levels, sprites
+
+N: Andrew Bassett
+S: andrewb
+E: orangejuices@icqmail.com
+D: music
+
+S: ravage
+E: dragon_69283@yahoo.com
+D: Sprites
+
+S: archvile46
+E: pudge@att.net
+D: levels
+
+S: tony
+E: awalker@air-internet.com
+D: textures
+
+S: spaceforce
+E: spaceforce@snohost.com
+D: levels
+
+S: CheapAlert
+S: gargoylol
+S: leileilol
+E: cheapalert@gmail.com
+D: graphics, sounds, flats, sprites
+
+N: Michael T. Cole
+S: ShadowRunner
+E: Clansr03@yahoo.com
+D: levels
+
+N: Kurt Kesler
+E: kesler@fidnet.com
+D: sprites
+
+S: Isle
+E: isle_bot@hotmail.com
+D: textures
+
+N: Ola Bjorling
+S: Citrus
+E: ukiro@ukiro.com
+D: textures
+
+S: ZarcyB
+E: korgon_iii@hotmail.com
+D: textures
+
+S: diluted
+E: shaggs2dope_00@hotmail.com
+D: textures
+
+S: Espi
+E: esa.repo@phnet.fi
+D: (a lot of) textures
+
+N: Ralph Vickers
+S: Ralphis
+E: ralphis@slipgate.org
+D: music
+
+S: Sir Fragsalot
+E: bssrpantella@hotmail.com
+D: stories, sprites
+
+N: Jeremy Stepp
+E: jeremystepp@hotmail.com
+D: textures
+
+N: Nicholai Main
+S: Oblivion
+E: uzi666@juno.com
+D: levels, fog colormap
+
+S: KMan
+E: kman@valveworld.com
+D: textures, sprites
+
+S: mystic
+E: murray6@blueyonder.co.uk
+D: levels
+
+N: Jon Rimmer
+S: Amtiskaw
+S: Jon_R
+E: jonr@frad.org
+W: http://destruct.alkali.org/
+D: textures
+
+N: Vincent Fong
+S: Vicious
+E: vincentfong@freecall-uk.co.uk
+D: musics
+
+N: Toby Collins Jr.
+S: tobester
+E: tobester666@yahoo.com
+D: music
+
+N: Andrew Francis
+S: locust
+E: locust@iinet.net.au
+D: textures
+
+S: AirRaid
+E: airraid666@yahoo.com
+D: sprites, levels, textures
+
+S: Jayextee
+E: Jxt@Misery.co.uk
+D: graphics, levels
+
+S: Enjay
+E: Enjay001@hotmail.com
+D: sounds
+
+N: Jonathan Dowland
+E: jon+Chiew6ye@alcopop.org
+W: http://jmtd.net/
+D: Former admin, website, FTP host and nightlies; textures; scripts; levels; hires zealotism; sounds
+
+S: Malice Rancor
+E: malicerancor@hotmail.com
+D: sprites
+
+N: Dale Sells
+S: mmnpsrsoskl
+E: mmnpsrsoskl@hotmail.com
+D: textures, graphics
+
+S: Meat_Head
+E: Forbidden_Planet@prodigy.net
+D: textures
+
+S: kaiser
+E: kaiser@newdoom.com
+D: levels
+
+S: Slayer226
+E: slayer226@hotmail.com
+D: textures
+
+S: Ebola
+E: ebola_kaell@home.se
+D: textures, sprites
+
+S: Zeurkous
+E: de_zeurkous@zonnet.nl
+D: sprites, textures
+
+N: Fredrik Johansson
+E: fredrik.johansson@gmail.com
+W: http://fredrikj.net/
+D: textures, sprites
+
+S: Lazer
+E: dafshin@mediaone.net
+D: textures, levels
+
+N: Steve Dudzik
+S: Lut
+E: toruonda@home.com
+D: sprites, levels
+
+N: Joseph Chang
+E: jchang@optusnet.com.au
+D: sprites
+
+S: Csabo
+E: wadedit@marchmail.com
+D: music
+
+S: Draconio
+E: draconio2001@yahoo.com
+D: sounds
+
+N: Dave Kiddell
+S: Mewse
+E: umkiddel@cc.umanitoba.ca
+W: http://mewse.alkali.org/
+D: graphics, Mewse!
+
+S: Deathmaster213
+E: deathmaster213@hotmail.com
+D: art/textures
+
+S: Hyena
+E: trwhite@fgbc.org
+D: sounds, musics, sprites, levels
+
+S: Nrkn
+E: nrkn@ihug.co.nz
+D: textures
+
+N: Tyler P.
+S: Picklehammer
+E: picklehammer@msn.com
+D: musics
+
+N: Alberto Bonis
+S: Saint of Killers
+E: alberto.bonis@libero.it
+D: sprites/art
+
+S: GeekMarine
+E: cooljohn@birdmail.com
+D: sprites, sounds
+
+N: Tom Robinson
+E: tom@alkali.org
+W: http://www.junked.org/
+D: A chunk of perl code
+
+N: Patrick "Amarande" Kalinauskas
+S: Amarande
+E: amarande@gmail.com
+D: levels
+
+N: Sean Gauthier
+S: Cacodemon Leader
+E: gauthier.home@sympatico.ca
+D: levels
+
+N: Luke Cama
+S: Spike
+E: spikeycool@hotmail.com
+D: sounds
+
+S: Shaviro
+E: maonth@nautrup.com
+D: textures
+
+S: Nightfang
+E: nightfang@truelights.com
+D: sprites
+
+S: MDenham
+E: tathetriam@aol.com
+D: levels
+
+S: SpinSpyder
+E: blcrowley@hotmail.com
+D: sprites
+
+N: Jeremy Elder
+S: SgtCrispy
+E: sha_nigtha@yahoo.com
+D: sounds, levels
+
+S: Submerge
+E: submerge_527@hotmail.com
+D: sounds, sprites
+
+S: Adamizer
+E: adamizer9000@yahoo.com
+D: aprites
+
+N: Andrew Apted
+E: ajapted@netspace.net.au
+D: graphics, levels, patches, sprites
+
+S: Zigmund
+E: z_ozwell@hotmail.com
+D: levels
+
+S: kinkyfriend
+N: Patrick Westermark
+E: kinkyfriend85@hotmail.com
+D: graphics
+
+S: Railgunner
+E: pcclassix@the-any-key.com
+D: sprites, levels
+
+S: bastetfurry
+E: bastetfurry@nachtkatzen.de
+D: levels
+
+S: Lurker
+E: ssjtrunks37@hotmail.com
+D: levels, sprites, sounds
+
+S: DarkStalker
+E: darkstalker81@hotmail.com
+D: textures
+
+S: Scuba Steve
+E: ray_stantz@hotmail.com
+D: sprites, graphics
+
+N: Kim Bach
+S: Torn
+E: Tornthedark@hotmail.com
+D: levels
+
+N: Mike Watson
+S: Cyb
+E: cyb@frad.org
+W: http://cyb.alkali.org/
+D: levels, sprites, lumps
+
+N: Wouter van Oortmerssen
+S: Aardappel
+E: aardappel@planetquake.com
+D: conceptual work and realisation
+
+N: Alex Mao
+S: Arioch
+E: arioch@despayre.org
+D: long term server hosting
+
+N: Bill Koch
+S: Bloodshedder
+E: bloodshedder@doomcenter.com
+D: sounds
+
+N: Corwin Brence
+S: WildWeasel
+E: wildweasel_lemon@hotmail.com
+D: sounds
+
+S: WildMan
+N: Rick Clark
+E: rickclark58@yahoo.com
+D: levels
+
+S: sargebaldy
+N: Owen Lloyd
+E: lloydo@onid.orst.edu
+D: levels
+
+N: David Aramant
+E: david_a00@excite.com
+D: sprites
+
+S: Silverwyvern
+E: cindymcc@nbnet.nb.ca
+D: graphics (skies)
+
+S: mouse
+S: lilwhitemouse
+E: lilwhitemo@midmaine.com
+D: sprites
+
+N: Simon Howard
+S: fraggle
+E: fraggle@soulsphere.org
+W: https://soulsphere.org
+D: project admin, scripting, build system, textures, sprites, graphics, lumps, manual, patches
+
+N: Joe Dowland
+E: jon+joefreedoom@alcopop.org
+D: sounds
+
+N: Jim McDougald
+S: rellik
+E: rellik_jmd@yahoo.com
+D: FreeDM levels, graphics
+
+N: Jason Root
+S: hellbent
+E: chesterules@yahoo.com
+D: FreeDM levels
+
+N: David Lawrence Ramsey
+S: dolorous
+E: pooka109@cox.net
+D: sounds
+
+S: Catoptromancy
+E: catoptromancy@yahoo.com
+D: levels, playtesting, bugfixes, textures
+
+S: muffins.exe
+D: sounds
+
+S: RjY
+E: rjy@users.sourceforge.net
+W: http://rjy.org.uk/
+D: levels
+
+N: Claude A Freeman
+S: CSonicGo
+D: sounds
+
+N: Eric Baker
+E: eabaker@san.rr.com
+S: The Green Herring
+D: levels
+
+E: hawkwinds_messages@hotmail.com
+S: Hawkwind
+D: levels
+
+S: acc
+D: levels
+
+S: Siggi
+D: levels
+
+N: Miguel Suarez Gomez
+E: thewadsfactorystaff@hotmail.com
+S: Zok
+D: levels
+
+E: ghostlydeath@gmail.com
+S: GhostlyDeath
+D: musics, PC speaker sounds
+
+N: Mark McGill-Smith
+E: isbetterthanyou@hotmail.com
+S: TheMisterCat
+D: musics
+
+N: Matthew Cibulas
+E: rottking@sbcglobal.net
+S: RottKing
+D: sounds
+
+N: Colin Kelly
+E: bankthemighty@gmail.com
+S: bank
+D: sounds
+
+N: Delano Cuzzucoli
+E: delano501@gmail.com
+S: Delano
+D: sprites
+
+N: Svante Ekholm
+E: svante.ekholm@gmail.com
+S: xerent
+D: levels
+
+N: Benjamin Debski
+E: benjamin.debski@gmail.com
+S: dabski
+D: levels
+
+N: G. Wessner
+E: masterstilgar@yahoo.com
+S: Stilgar
+D: sounds
+
+S: Jute
+E: jutemail@gmail.com
+D: music
+
+N: Wesley D. Johnson
+E: johnson2412@usgo.net
+D: levels
+
+N: Ulises Lozano
+S: Urric Hammersong
+E: calators@hotmail.com
+D: sprites
+
+N: Andrew Rehberger
+E: malinku@live.com
+S: Malinku
+D: levels
+
+S: Archfile
+D: levels
+
+S: Blastfrog
+E: soliver486@gmail.com
+D: graphics, sprites, sounds
+
+N: Brett Harrell
+S: Mechadon
+E: mekaddonn@gmail.com
+D: levels
+
+S: nivha
+D: levels
+
+S: hex11
+E: hex11@mail.com
+D: levels
+
+N: Luiz Henrique Gasparin Jerônimo
+S: Xindage
+E: xindage@gmail.com
+D: levels, textures
+
+S: Mithran Denizen
+E: jlebl755@mtroyal.ca
+D: sprites
+
+S: Z86
+D: sprites
+
+N: Matt Cadirao
+S: horncomposer
+D: genmidi instruments
+
+S: BaronOfStuff
+W: https://www.youtube.com/user/BaronOfStuff
+D: sprites
+
+N: Josef Šustek
+S: Paar
+E: sustek.josef@gmail.com
+D: levels
+
+N: Dean Joseph
+S: deathz0r
+E: deathz0r@unidoom.org
+D: levels
+
+N: Alexandre-Xavier Labonté-Lamoureux
+S: AXDOOMER
+E: alexandrexavier@live.ca
+D: patches, levels, graphics, sprites
+
+N: Daniel Jewell
+S: Jewellds
+E: jewellds@gmail.com
+D: levels
+
+N: Adrian Cabrera
+E: cancer_kaoru@live.com
+S: raymoohawk
+W: http://raymoohawk.deviantart.com/
+D: sprites
+
+S: agaures
+E: zalsorarakia@gmail.com
+D: sprites
+
+N: Mikael Haladyn
+E: mikaelhhome@yahoo.dk
+S: nub_hat
+D: levels, musics
+
+S: CaptainW
+E: avortement.rate@gmail.com
+D: graphics
+
+N: Ilja Sara
+E: ilja.sara@kahvipannu.com
+D: levels
+
+N: Mike Swanson
+S: chungy
+E: mikeonthecomputer@gmail.com
+D: project admin, build system, repo maintenance
+
+N: Cray Elliott
+S: mp2e
+E: MP2E@archlinux.us
+D: lumps (demos, playtesting)
+
+S: voltcom9
+E: Earthbound.Glenn@gmail.com
+D: level/episode names
+
+S: jmickle
+E: jaymickle@gmail.com
+D: music
+
+S: doomkid
+E: thedevilzworker@hotmail.com
+D: freedm playtesting and demo participation
+
+S: mogul
+N: Jeremy Emerson
+D: music
+
+S: sergeant_mark_iv
+N: Marcos Abenante
+E: marcos.mk3@outlook.com
+D: sprites
+
+S: bloax
+D: sprites
+
+S: undead003
+E: undead0003@gmail.com
+D: sounds
+
+S: angry_saint
+E: mechanicalambassador@gmail.com
+D: levels
+
+S: noose
+E: noozearts@gmail.com
+D: sprites
+
+S: mazmon
+N: Maz Hades
+E: mazhades@yahoo.com
+D: sprites
+
+S: jaws_in_space
+N: Micah Petersen
+E: jawsinspace@gmail.com
+D: levels
+
+S: eriance
+N: Eric Ou
+E: eriance@gmail.com
+W: http://amuscaria.deviantart.com/
+D: sprites
+
+S: zrrion
+N: Roth Smith
+E: zrrion@gmail.com
+W: http://zrrion.deviantart.com/
+D: sprites
+
+S: kracov
+N: Kracov Bolkonski
+E: kracov.wolf@gmail.com
+W: http://kracov.org/
+D: graphics
+
+S: robotdog1
+D: sprites, patches
+
+E: mobiusx49@gmail.com
+S: cwolfru
+D: levels
+
+S: Jimmy
+N: James Paddock
+E: jamespaddock@hotmail.com
+D: levels
+
+N: Michael Jurich
+E: midwestgenius@gmail.com
+D: levels
+
+S: LuckyPunk
+E: luckypunk322@gmail.com
+D: sprites
+
+S: Blueworrior
+N: Lola Harvey
+E: BlueWorrior@hotmail.co.uk
+D: musics
+
+S: sajbear
+N: Kristian Nilsen
+E: sajber@sajber.info
+W: http://sajber.info
+D: level
+
+S: Voros
+N: Ayub Ahmed
+E: ayubahmed2240@gmail.com
+D: textures, lumps
+
+S: Hexereticdoom
+N: Angel C.F.
+E: hexereticdoom@gmail.com
+W: http://www.moddb.com/members/hexereticdoom
+D: sprites
+
+S: SeventhSentinel
+N: James Hall
+W: http://seventhsentinel.net23.net
+D: sounds
+
+S: Viscra Maelstrom
+E: doomhunter_175@hotmail.com
+D: musics
+
+S: bytebeats
+E: bytebytebeats@gmail.com
+D: musics
+
+S: KevinHEZ
+N: Kevin Martins
+E: kevinmss14@gmail.com
+D: musics
+
+S: agenten
+E: wagnerc27@gmail.com
+W: https://twitch.tv/gajmegenten/profile
+D: textures
+
+S: pan-te
+D: levels
+
+S: YukiHerz
+N: Gabriel Antonio
+E: gabriel.reinoso.1996@gmail.com
+D: levels
+
+S: JudgeDeadd
+E: korodzik@lavabit.com
+D: level names
+
+S: DragonMorpheus
+D: level names
+
+S: cr0wb4r
+D: level names
+
+N: Edgar Muniz Berlinck
+E: edgar.vv@gmail.com
+D: Appstream XML files
+
+S: Gentlepoke
+E: doom@gpoke.com
+W: http://gpoke.com/
+D: level names
+
+S: Heng
+E: heng@deepthought.earth
+D: sprites
+
+S: uhbooh
+E: Uhbooh2@hotmail.com
+D: textures
+
+S: Litrivin
+D: textures
+
+S: jupiter_ex
+N: Matias M. Roldan
+E: ttrgrmmtn@yahoo.com.ar
+D: musics, sounds
+
+N: Fernando Carmona Varo
+S: ferk
+E: ferkiwi@gmail.com
+D: graphics (titlepic)
+
+N: Kevin Caccamo
+S: Talon1024
+E: kevin@ciinet.org
+D: textures, flats, sounds
+
+S: BobFromReboot
+N: Bradley Lavigne
+E: bradleylavigne@gmail.com
+D: musics
+
+S: Elon_Satoshi
+E: elonsatoshi@riseup.net
+D: sounds
+
+S: Eradrop
+E: samurai00020@walla.com
+D: patches
+
+S: Hambourgeois
+D: flats, textures
+
+S: Jared Deberjerak
+D: textures
+
+S: Mortrixs19
+D: levels
+
+S: GooseJelly
+N: Nathaniel Patasky
+E: n.patasky@gmail.com
+D: buildcfg.txt, CREDITS, levels
+
+S: Craneo
+E: memod_99@hotmail.com
+D: sprites (technospider reshade, minigunner, combat slug flash), textures
+
+S: continuum.mid
+S: northivanastan
+N: Ivan Stanton
+E: northivanastan@gmail.com
+D: musics
+
+S: MothraMaster
+D: sprites: Zombieman/Shotgunners boots update
+
+S: Korp
+E: korpkat@gmail.com
+D: Sprites, Textures, Musics, buildcfg.txt, patches, sounds
+
+S: ajanddino
+N: Anthony Pierce
+E: ajanddino@gmail.com
+D: musics
+
+S: /dev/urandom
+E: dev.urandom@posteo.org
+D: graphics, patches, sprites
+
+S: AerialB
+D: COPYING.adoc
+
+S: basedSkeleton
+D: sprites
+
+S: boogiebogus
+D: buildcfg.txt, sprites
+
+S: Chexter
+D: patches
+
+S: ConsumingCritic
+D: levels
+
+S: Eonfge
+E: contact@kevindegeling.nl
+D: dist
+
+N: Erick Tenorio
+S: guynamederick
+E: guynamederick@gmail.com
+D: graphics, levels, lumps, sounds, sprites
+
+N: Fabian Greffrath
+E: fabian@greffrath.com
+D: buildcfg.txt, graphics, levels, lumps
+
+S: Rei
+N: Reinaldo
+E: crumbscrunchydelights@gmail.com
+D: buildcfg.txt, lumps, manual, sounds, sprites, flats
+
+N: Hugo Locurcio
+E: hugo.locurcio@hugo.pro
+D: buildcfg.txt, dist, manual
+
+N: Jason Yundt
+E: swagfortress@gmail.com
+D: levels
+
+S: kitchen-ace
+E: 68k@quikphix.org
+D: levels, patches
+
+S: m
+E: verdantdregs@shaw.ca
+D: levels, sounds, sprites, textures, manual
+
+S: mkrupczak3
+E: matthew@krupczak.org
+D: manual
+
+N: Nicholas Zatkovich
+S: NickZ
+E: nzatkovich@gmail.com
+D: buildcfg.txt, COMPILING.adoc, CREDITS, .gitattributes, .github, .gitignore, graphics, levels, lumps, patches, scripts, sprites
+
+S: Obsidian Plague
+D: musics
+
+N: Perry Fraser
+S: perry
+E: me@pprogs.blog
+D: levels
+
+N: Ada Mackiewicz
+S: Shinosarna
+E: nobody.shinobi@gmail.com
+D: buildcfg.txt, levels, sprites
+
+N: Steven Elliott
+E: selliott512@gmail.com
+D: buildcfg.txt, BUILD-SYSTEM.adoc, levels, Makefile, README.adoc, scripts, sprites
+
+N: Tyler True
+D: Makefile
+
+S: BeachThunder
+D: levels
+
+N: Clayton Sobrino
+E: ClaytonSobrino@yahoo.com
+D: patches
+
+N: Colton G. Rushton
+E: colton51919@gmail.com
+D: lumps
+
+S: drbugbait
+E: arlesschill@hotmail.com
+D: lumps
+
+S: igdegoo
+D: COPYING.adoc, lumps, musics
+
+S: inkoalawetrust
+D: levels
+
+S: MissLav
+D: patches
+
+S: unfa
+E: unfa00@gmail.com
+D: sounds
+
+N: William Breathitt Gray
+E: vilhelm.gray@gmail.com
+D: dist
+
+S: DOGB01
+D: levels
+
+S: arborix
+D: sprites
+
+S: Inuk
+E: inuquire@gmail.com
+D: levels
+
+S: GojiBerry
+E: gojidoesit@proton.me
+D: sounds, musics, textures
+
+N: Jaden LeMieux
+S: iRedMC
+E: jadenquinn8@hotmail.com
+W: http://iredmc.us.to/
+D: levels, musics
+
+N: Cass Python
+S: Owly
+E: owlgal69@protonmail.com
+W: https://owly.fans
+D: Freedoom website
+
+S: Matzu
+D: musics
+
+S: ZeMystic
+D: musics
+
+S: R0rque
+D: musics
+
+S: rostuhan
+E: rostuhan123@gmail.com
+D: musics
+
+S: SuperDave938
+D: textures
+
+S: Cascade
+D: sprites
+
+S: Berubaretto
+D: levels
+
+N: Enzo Carozza
+S: uni
+E: enzoc@tuta.io
+D: CREDITS-LEVELS, CREDITS-MUSIC, levels, musics, buildcfg.txt, level names
+
+S: MoonDeLaAxel
+D: sounds, musics, textures
+
+S: klickach
+D: textures
+
+S: Magnolia
+D: sprites
+
+S: Anonymoister
+D: sprites
+
+N(A): Josephus Astartes
+S: DH4050
+D: musics
+
+S: Scragadelic
+D: musics
+
+S: Woolie Wool
+D: musics
+
+S: wastedjamacan
+D: musics
+
+S: SUNPYG Senpai
+D: levels
+
+S: Ospaggi
+D: musics
+
+S: Stratos
+D: musics
+
+S: Hayden49
+D: levels
+
+S: Teh_Bucket
+W: https://opengameart.org/users/tehbucket
+D: sprites
+
+N: Dmytro Moskovchenko
+S: Dimon12321
+E: d.moskowchenko@gmail.com
+D: levels

--- a/docs/freedoom-docs/CREDITS-LEVELS
+++ b/docs/freedoom-docs/CREDITS-LEVELS
@@ -1,0 +1,155 @@
+--Phase 1--
+
+Episode 1 - Outpost Outbreak
+    E1M1: Outer Prison by Gabriel "YukiHerz" Antonio
+    E1M2: Communications Center by acc
+    E1M3: Waste Disposal by Josef "Paar" Šustek
+        E1M9: Nutrient Recycling by Mortrixs19
+    E1M4: Supply Depot by GeekMarine
+    E1M5: Armory by Oleg "Wereknight" Vovk
+    E1M6: Training Facility by GeekMarine
+    E1M7: Xenobiotic Materials Lab by Will "Kid Airbag" Hackney
+    E1M8: Outpost Quarry by Luiz Henrique "Xindage" Gasparin Jeronimo
+
+Episode 2 - Ruin Upon Ruin
+    E2M1: Elemental Gate by Luiz Henrique "Xindage" Gasparin Jeronimo and m
+    E2M2: Shifter by Hayden49
+    E2M3: Reclaimed Facilities by SUNPYG Senpai
+    E2M4: Flooded Installation by Luiz Henrique "Xindage" Gasparin Jeronimo
+    E2M5: Underground Hub by Luiz Henrique "Xindage" Gasparin Jeronimo
+        E2M9: Fortress 31 by Miguel "Z0k" Suarez Gomez
+    E2M6: Hidden Sector by Catoptromancy
+    E2M7: Control Complex by Luiz Henrique "Xindage" Gasparin Jeronimo
+    E2M8: Containment Cell by Luiz Henrique "Xindage" Gasparin Jeronimo
+
+Episode 3 - Event Horizon
+    E3M1: Land of the Lost by Jay "Jayextee" Trent
+    E3M2: Geothermal Tunnels by pan-te
+    E3M3: Sacrificial Bastion by Jeremy "SgtCrispy" Elder
+    E3M4: Oblation Temple by Mortrixs19 and Erick "GuyNamedErick" Tenorio
+    E3M5: Infernal Hallows by SUNPYG Senpai
+    E3M6: Igneous Intrusion by Archfile
+        E3M9: Acquainted With Grief by Angry Saint
+    E3M7: No Regrets by Sean "Cacodemon Leader" Gauthier
+    E3M8: Ancient Lair by Kim "Torn" Bach
+
+Episode 4 - Double Impact
+    E4M1: Maintenance Area by Matt "RottKing" Cibulas and Ralph "Ralphis" Vickers
+    E4M2: Research Complex by Matt "RottKing" Cibulas and Ralph "Ralphis" Vickers
+        E4M9: Operations by Matt "RottKing" Cibulas and Ralph "Ralphis" Vickers
+    E4M3: Central Computing by Matt "RottKing" Cibulas and Ralph "Ralphis" Vickers
+    E4M4: Hydroponic Facility by Matt "RottKing" Cibulas and Ralph "Ralphis" Vickers
+    E4M5: Engineering Station by Matt "RottKing" Cibulas and Ralph "Ralphis" Vickers
+    E4M6: Command Center by Matt "RottKing" Cibulas and Ralph "Ralphis" Vickers
+    E4M7: Waste Treatment by Matt "RottKing" Cibulas and Ralph "Ralphis" Vickers
+    E4M8: Launch Bay by Matt "RottKing" Cibulas and Ralph "Ralphis" Vickers
+
+
+--Phase 2--
+
+Cluster 1
+    MAP01: Hydroelectric Plant by Samuel "Blastfrog" Oliver, Luiz Henrique "Xindage" Gasparin Jeronimo and Jon Dowland
+    MAP02: Filtration Tunnels by Stephen "Siggi" Finniss
+    MAP03: Crude Processing Center by Jeremy "SgtCrispy" Elder
+    MAP04: Containment Bay by Mark "Macro11_1" Pedersen
+    MAP05: Sludge Burrow by Patrick "Amarande" Kalinauskas
+    MAP06: Janus Terminal by Jay "Jayextee" Trent
+    MAP07: Logic Gate by Mortrixs19
+    MAP08: Astronomy Complex by Boris Iwanski
+    MAP09: Datacenter by Kristian "sajbear" Nilsen
+    MAP10: Deadly Outlands by Svante "Xerent" Ekholm
+    MAP11: Dimension Rift Observatory by Samuel "Kaiser" Villarreal
+
+Cluster 2
+    MAP12: Railroads by Miguel "Z0k" Suarez Gomez
+    MAP13: Station Earth by Jay "Jayextee" Trent
+    MAP14: Nuclear Zone by Jay "Jayextee" Trent
+    MAP15: Hostile Takeover by Miguel "Z0k" Suarez Gomez
+        MAP31: Be Quiet by Jay "Jayextee" Trent
+            MAP32: Not Sure by Catoptromancy
+    MAP16: Urban Jungle by Tom "Hyena" White
+    MAP17: City Capitol by Jay "Jayextee" Trent
+    MAP18: Aquatics Lab by James "Jimmy" Paddock
+    MAP19: Sewage Control by Jay "Jayextee" Trent
+    MAP20: Blood Ember Fortress by Devin "Lazer" Afshin
+
+Cluster 3
+    MAP21: Under Realm by Mortrixs19
+    MAP22: Remanasu by Boris Iwanski
+    MAP23: Underground Facility by Joel "Submerge" Poston
+    MAP24: Abandoned Teleporter Lab by Jay "Jayextee" Trent
+    MAP25: Persistence of Memory by Mike "Cyb" Watson
+    MAP26: Dark Depths by Nathaniel "GooseJelly" Patasky and m
+    MAP27: Palace of Red by DOGB01
+    MAP28: Grim Redoubt by Miguel "Z0k" Suarez Gomez
+    MAP29: Melting Point by Patrick "Amarande" Kalinauskas
+    MAP30: Jaws of Defeat by Sean "Cacodemon Leader" Gauthier
+
+
+--FreeDM--
+
+    DM01: Tech Test by Luiz Henrique "Xindage" Gasparin Jeronimo
+    DM02: Natural Selection by Jason "Hellbent" Root
+    DM03: Issues of Claveria by Luiz Henrique "Xindage" Gasparin Jeronimo
+    DM04: Steel by Dean "deathz0r" Joseph
+    DM05: Dense Fields by Luiz Henrique "Xindage" Gasparin Jeronimo
+    DM06: Temple of Ammon by Catoptromancy and Luiz Henrique "Xindage" Gasparin Jeronimo
+    DM07: Main Stronghold by Jim "Rellik" McDougald
+    DM08: Artifact Base by Alexandre-Xavier "AXDOOMER" Labonté-Lamoureux
+
+    DM09: Industrial Outland by Luiz Henrique "Xindage" Gasparin Jeronimo
+    DM10: Detached Grounds by Luiz Henrique "Xindage" Gasparin Jeronimo
+    DM11: Isolated Facility by Luiz Henrique "Xindage" Gasparin Jeronimo
+    DM12: Up 'n' Down Canyon by Catoptromancy
+    DM13: Unholy Blood by Catoptromancy and Luiz Henrique "Xindage" Gasparin Jeronimo
+    DM14: Technical Assault by Luiz Henrique "Xindage" Gasparin Jeronimo
+    DM15: Shallow Complex by Luiz Henrique "Xindage" Gasparin Jeronimo
+    DM16: Barren Alleys by Luiz Henrique "Xindage" Gasparin Jeronimo
+
+    DM17: Underwoods by Luiz Henrique "Xindage" Gasparin Jeronimo
+    DM18: Deserted Courtyard by Luiz Henrique "Xindage" Gasparin Jeronimo
+    DM19: Tech Isle by Luiz Henrique "Xindage" Gasparin Jeronimo
+    DM20: Warehouse by Luiz Henrique "Xindage" Gasparin Jeronimo
+    DM21: Refinery by Jim "Rellik" McDougald
+    DM22: Military Depot by Alexandre-Xavier "AXDOOMER" Labonté-Lamoureux
+    DM23: Confrontation by hex11
+    DM24: Flooded Base by Brett "Mechadon" Harrell
+
+    DM25: Mansion Yard by Catoptromancy
+    DM26: Acidic Crypt by Luiz Henrique "Xindage" Gasparin Jeronimo
+    DM27: The Exile by Jim "Rellik" McDougald
+    DM28: Weapons Facility by Jim "Rellik" McDougald
+    DM29: Unusual Territory by Luiz Henrique "Xindage" Gasparin Jeronimo
+    DM30: Last Man Standing by Dean "deathz0r" Joseph
+    DM31: Desolated Fort by Luiz Henrique "Xindage" Gasparin Jeronimo
+    DM32: Fourplay by Brett "Mechadon" Harrell
+
+
+--Previously Featured in 0.12.1--
+
+E1M5: Main Control by Miguel "Z0k" Suarez Gomez
+E1M7: Transportation Bay by Will "Kid Airbag" Hackney (renamed, not removed)
+E1M9: Armory by Oleg "Wereknight" Vovk (moved to E1M5, not removed)
+E2M1: Ruins by Luiz Henrique "Xindage" Gasparin Jeronimo
+E2M2: Power Plant by Andrew "Malinku" Rehberger
+E2M3: Archaeology Site by Luiz Henrique "Xindage" Gasparin Jeronimo (moved to E2M5 and renamed, not removed)
+E2M4: Sample Holding Site by Catoptromancy (moved to E2M6 and renamed, not removed)
+E2M5: Fortress 31 by Miguel "Z0k" Suarez Gomez (moved to E2M9, not removed)
+E2M6: Trepidation Site by Oleg "Wereknight" Vovk
+E2M7: Quarantine Vessel by Oleg "Wereknight" Vovk
+E2M9: Corruption of Man by Emmanuel "G0dCells" Rousseau, Archfile and Luiz Henrique "Xindage" Gasparin Jeronimo
+E3M2: Infernal Caverns by pan-te
+E3M3: Derelict Temple by pan-te (moved to E3M2 and renamed, not removed)
+E3M4: Sacrificial Bastion by Jeremy "SgtCrispy" Elder (moved to E3M3, not removed)
+E3M5: Oblation Temple by Mortrixs19 and Erick "GuyNamedErick" Tenorio (moved to E3M4, not removed)
+
+MAP07: Outer Storage Warehouse by Boris Iwanski
+MAP11: Infinite Plain by Samuel "Kaiser" Villarreal (renamed, not removed)
+MAP21: Under Realm by Patrick "Amarande" Kalinauskas
+MAP25: Red Works by Mike "Cyb" Watson (renamed, not removed)
+MAP26: Dark Depths by Nathaniel "GooseJelly" Patasky
+MAP27: Warped Elementality by Patrick "Amarande" Kalinauskas
+MAP29: Last Stand by Patrick "Amarande" Kalinauskas (renamed, not removed)
+
+DM22: Fourplay by Brett "Mechadon" Harrell (moved to DM32, not removed)
+DM32: Chocolate by Luiz Henrique "Xindage" Gasparin Jeronimo

--- a/docs/freedoom-docs/CREDITS-MUSIC
+++ b/docs/freedoom-docs/CREDITS-MUSIC
@@ -1,0 +1,211 @@
+--Phase 1--
+
+Title: "Fight for Freedom" by Korp, based on "Fountain Dance" by Tyler "Picklehammer" P.
+Intermission: "YOU LIVE!!!!" by Stratos
+Victory: "Distance" by Korp
+Bunny: "Impactean Welcome Party" by Goji
+
+Episode 1 - Outpost Outbreak
+	E1M1: "Stanky Leg Specialist" by Lola "BlueWorrior" Harvey
+	E1M2: "Look At Me I'm Underhalls Too" by Mark "TheMisterCat" McGill-Smith
+	E1M3: "Alone with Colors" by Kevin "Velvetic" Martins & Jonathan "julnen" Martins
+		E1M9: "Hidden Between Spades" by Korp, remix of dave3d42.mid by jute
+	E1M4: "Flood the City" by Kevin "Velvetic" Martins & Jonathan "julnen" Martins
+	E1M5: e1m1.mid by Ralph "Ralphis" Vickers
+	E1M6: "Oxidine" by Korp, remix of dave3d35.mid by jute
+	E1M7: "Totally Surrounded" by Josephus "DH4050" Astartes
+	E1M8: "On the Next Day" by Kevin "Velvetic" Martins
+
+Episode 2 - Ruin Upon Ruin
+	E2M1: "Moonstone" by Korp
+	E2M2: "Voidgaze" by Korp
+	E2M3: "Workout" by Korp
+	E2M4: "Diodine" by Korp
+	E2M5: "Reminiscence" by Korp
+		E2M9: "Nightstorm" by Korp
+	E2M6: "Concept of Technology" by Korp
+	E2M7: "Ribcage" by Korp
+	E2M8: "Treble Dissension" by Korp
+
+Episode 3 - Event Horizon
+	E3M1: "Intrare In Infernum" by Lola "BlueWorrior" Harvey
+	E3M2: "The Long Road" by Lola "BlueWorrior" Harvey
+	E3M3: "Wrought Havoc" by Lola "BlueWorrior" Harvey
+	E3M4: "Cautious Progress" by Lola "BlueWorrior" Harvey
+	E3M5: "Scorned by Flesh" by Lola "BlueWorrior" Harvey
+	E3M6: "Soul Banisher" by Lola "BlueWorrior" Harvey
+		E3M9: "No-Clip to the End" by Lola "BlueWorrior" Harvey
+	E3M7: "Ultamatum Infurnus" by Lola "BlueWorrior" Harvey
+	E3M8: "The Zenith" by Lola "BlueWorrior" Harvey
+
+Episode 4 - Double Impact
+	E4M1: "Liberate the Stars" by continuum.mid
+	E4M2: "Fight Harder... To Obtain a Better Victory!" by Proxy-MIDI
+		E4M9: "The Deepest Secrets" by continuum.mid
+	E4M3: "Space Spectre" by Matzu
+	E4M4: "Deliberate Concealment" by continuum.mid
+	E4M5: "Main Code" by Korp
+	E4M6: "Andromeda" by ZeMystic
+	E4M7: "Ambiguity" by Korp
+	E4M8: "Vs. The Assault Quindecapod" by continuum.mid
+
+
+--Phase 2--
+
+Title: "Horizon's Call" by Korp
+Intermission: "FTW You 100" by Lola "BlueWorrior" Harvey
+Story: dave3d07.mid by jute
+
+Cluster 1
+	MAP01: "Not My First Rodeo..." by Lola "BlueWorrior" Harvey
+	MAP02: "Dark Underworld" by Lola "BlueWorrior" Harvey
+	MAP03: "Demon Dance" by Discoholic
+	MAP04: "Indigo" by Korp
+	MAP05: "Under Maintenance" by Lola "BlueWorrior" Harvey
+	MAP06: "Refrigeration" by Korp, based on "Dark Trail" by Tyler "Picklehammer" P.
+	MAP07: "Light 'Em Up, Boyz!" by Lola "BlueWorrior" Harvey and Goji
+	MAP08: "Syntax Error" by Lola "BlueWorrior" Harvey
+	MAP09: "Terrible Secrets" by Lola "BlueWorrior" Harvey
+	MAP10: "Soviet Porno" by Jeremy "Vandalorian" Emerson
+	MAP11: "Undergrowth" by Korp, remix of dave3d01.mid by jute
+
+Cluster 2
+	MAP12: "Sewers" by Discoholic, remix of "Wasteland Scavengers" by Samuel "Blastfrog" Oliver
+	MAP13: "Fear" by Discoholic
+	MAP14: "About the Summer" by Kevin "Velvetic" Martins & Jonathan "julnen" Martins
+	MAP15: "Backpack of Shells" by Lola "BlueWorrior" Harvey
+		MAP31: "The Machine" by Lola "BlueWorrior" Harvey
+			MAP32: "Black Mountain" by Kevin "Velvetic" Martins & Jonathan "julnen" Martins
+	MAP16: "Reflection" by Scragadelic
+	MAP17: "Mow Them Down!" by Lola "BlueWorrior" Harvey
+	MAP18: "Realistic Approach" by Kevin "Velvetic" Martins
+	MAP19: "Deceit" by Julian "Julian Hope" Aubourg, modified by m
+	MAP20: "Beasts of Horizon" by Josephus "DH4050" Astartes
+
+Cluster 3
+	MAP21: "Rough Landing" by Korp, remix of dave3d08.mid by jute
+	MAP22: "Alien Waltz" by Korp
+	MAP23: "Within the Trilo's Den" by MoonDeLaAxel and Korp
+	MAP24: "Space's Despair" by Korp, remix of "Balancing Act" by Andrew Bassett
+	MAP25: "I Sought Wisdom in the Chalice But There Was None" by Jeremy "Vandalorian" Emerson
+	MAP26: "Stormer" by Korp, originally by Samuel "Blastfrog" Oliver
+	MAP27: "Dreamcatcher (Black and Blue)" by Kevin "Velvetic" Martins & Jonathan "julnen" Martins
+	MAP28: "Skull Underfoot" by Lola "BlueWorrior" Harvey
+	MAP29: "Mists Over the Mire" by Tyler "Picklehammer" P.
+	MAP30: "Devoured by the Jaws of Defeat" by Korp, based on "Paranoia" by Tyler "Picklehammer" P.
+
+
+--FreeDM--
+
+Title: "My Home, The Colosseum" by Goji
+Intermission: "Burn the Bodies" by Tyler "Picklehammer" P.
+Story: "Geoff's Vinyl Collection" by MoonDeLaAxel, remix of "Why?" by Joshua "wastedjamacan" Masek
+
+	DM01: "Zero Fort" by Ralph "Ralphis" Vickers
+	DM02: "Descent from Grace" by Lola "BlueWorrior" Harvey
+	DM03: "Dynamite!" by Korp
+	DM04: "Liminal Space" by Lola "BlueWorrior" Harvey
+	DM05: "Music for Freedoom 9" by Jeremy "Vandalorian" Emerson
+	DM06: "Tunnel" by Anthony "Ajanddino" Pierce
+	DM07: "I Fell Off The Stairs" by Korp
+	DM08: "Jump Is Not Allowed!" by Korp
+
+	DM09: "Method to My Madness" by Matias "jupiter_ex" Roldan
+	DM10: "Paranoia" by Tyler "Picklehammer" P.
+	DM11: "Death's Embrace" by Tyler "Picklehammer" P.
+	DM12: "Parallax" by Korp
+	DM13: "Shut It" by Korp
+	DM14: "The Heroic Battle" by Tyler "Picklehammer" P.
+	DM15: "Neat" by Ralph "Ralphis" Vickers
+	DM16: "Deathmatch Construct" by Korp
+
+	DM17: "Panic" by Anthony "Ajanddino" Pierce
+	DM18: "Metadata" by Korp
+	DM19: "Tap Water" by Korp, remix of dave3d27.mid by jute
+	DM20: "Quirkspitter" by Korp, remix of dave3d16.mid by jute
+	DM21: "Friendly Fire" by Korp
+	DM22: "Red Foot" by Kevin "Velvetic" Martins and Simone Alauk
+	DM23: "Shells" by Ospaggi
+	DM24: "Constructive Criticism" by Matias "jupiter_ex" Roldan
+
+	DM25: "Shoot 'em All" by rostuhan
+	DM26: "World of Pain" by Josephus "DH4050" Astartes
+	DM27: "White Lights" by Kevin "Velvetic" Martins and Jonathan "julnen" Martins
+	DM28: "Bobby Sent Me" by Ralph "Ralphis" Vickers
+	DM29: "SevenFour" by Ralph "Ralphis" Vickers
+	DM30: "Freedom for Your Shooting Skills" by rostuhan
+	DM31: "The Syntax of Time" by Kevin "Velvetic" Martins
+	DM32: "Bullet Hell" by rostuhan
+
+
+--Previously Featured in 0.13.0--
+
+E1M5: "The Raging Sun" by Kevin "Velvetic" Martins & Jonathan "julnen" Martins, modified by Goji
+
+MAP07: "Fun is Infinite at AGM" by continuum.mid
+
+--Previously Featured in 0.12.1--
+
+Phase 1 Title: "Fountain Dance" by Tyler "Picklehammer" P.
+Phase 1 OPL Title: "I Hate Fredrik Johansson" by Toby "Tobester" Collins Jr.
+Phase 1 Intermission: "Music for Freedoom 10" by Jeremy "Vandalorian" Emerson
+Victory: "Ominous Theme" by Jared "BlackJar72" Blackburn
+Bunny: "Look At The Bunnies" by RestlessRodent
+E1M1: e1m1.mid by Ralph "Ralphis" Vickers (moved to E1M5, not removed)
+E1M3: "Mortal" by Jeremy "Vandalorian" Emerson
+E1M5: "sit on a bench 'n release that tensh'n" by Jazz "jmickle" Mickle
+E1M6: dave3d35.mid by jute
+E1M7: "Sewers" by Discoholic, remix of "Wasteland Scavengers" by Samuel "Blastfrog" Oliver (moved to MAP12, not removed)
+E1M9: "The Raging Sun" by Kevin "Velvetic" Martins and Jonathan "julnen" Martins
+E2M1: dave3d38.mid by jute
+E2M2: "Animal Skin" by Kevin "Velvetic" Martins and Jonathan "julnen" Martins
+E2M3: "Alone with Colors" by Kevin "Velvetic" Martins and Jonathan "julnen" Martins (moved to E1M3, not removed)
+E2M4: "Let 'em Burn" by Kevin "Velvetic" Martins
+E2M5: "Music for Freedoom 1" by Jeremy "Vandalorian" Emerson
+E2M6: "sit on a bench 'n release that tensh'n" by Jazz "jmickle" Mickle
+E2M7: "Music for Freedoom 3" by Jeremy "Vandalorian" Emerson
+E2M8: "Pit" by Anthony "Ajanddino" Pierce (moved to DM04, not removed)
+E2M9: dave3d34.mid by jute
+E3M9: "Lipstick" by Jeremy "Vandalorian" Emerson
+
+Phase 2 + FreeDM Title: "Warpath" by Tyler "Picklehammer" P.
+Phase 2 Intermission: "Burn the Bodies" by Tyler "Picklehammer" P.
+MAP04: "Soviet Porno" by Jeremy "Vandalorian" Emerson (moved to MAP10, not removed)
+MAP06: "Dark Trail" by Tyler "Picklehammer" P.
+MAP07: "Riders of Hell" by Tyler "Picklehammer" P.
+MAP10: "Death's Embrace" by Tyler "Picklehammer" P. (moved to DM11, not removed)
+MAP11: dave3d02.mid by jute
+MAP12: Doom2Alt.mid by Bradley "BobFromReboot" Lavigne
+MAP20: dave3d05.mid by jute
+MAP21: "Violence Culture" by Jeremy "Vandalorian" Emerson
+MAP22: "Mists Over the Mire" by Tyler "Picklehammer" P. (moved to MAP29, not removed)
+MAP23: dave3d09.mid by jute
+MAP24: "Balancing Act" by Andrew Bassett
+MAP26: "Crawl" by Jeremy "Vandalorian" Emerson
+MAP29: freedoom.mid by Varis Alpha
+MAP30: "Paranoia" by Tyler "Picklehammer" P. (moved to DM10, not removed)
+
+DM03: "Music for Freedoom 2" by Jeremy "Vandalorian" Emerson
+DM04: "Rush" by Kevin "Velvetic" Martins and Simone Alauk
+DM05: map01.mid by Ralph "Ralphis" Vickers
+DM06: "The Heroic Battle" by Tyler "Picklehammer" P. (moved to DM14, not removed)
+DM07: dave3d30.mid by jute
+DM08: Dave3d13.mid by jute
+DM10: Doom1.mid by Bradley "BobFromReboot" Lavigne
+DM11: "Spamhambled In Space" by Mark "TheMisterCat" McGill-Smith
+DM12: dave3d24.mid by jute
+DM13: e1m1.mid by Ralph "Ralphis" Vickers
+DM14: "Munt Battle" by Mark "TheMisterCat" McGill-Smith
+DM16: dave3d02.mid by jute
+DM17: "Surrounded Panic" by Vincent "Vicious" Fong
+DM18: dave3d06.mid by jute
+DM19: dave3d27.mid by jute
+DM20: dave3d16.mid by jute
+DM21: dave3d12.mid by jute
+DM23: dave3d17.mid by jute
+DM25: dave3d20.mid by jute
+DM26: dave3d09.mid by jute
+DM27: "Music for Freedoom 7" by Jeremy "Vandalorian" Emerson
+DM30: dave3d01.mid by jute
+DM32: "Munt Battle" by Mark "TheMisterCat" McGill-Smith
+

--- a/docs/freedoom-docs/README.adoc
+++ b/docs/freedoom-docs/README.adoc
@@ -1,0 +1,249 @@
+= Freedoom
+
+The Freedoom project aims to create a complete, free content first
+person shooter game, but _Freedoom_ by itself is just the raw material
+for a game.  It must be paired with a compatible _Doom_ engine to be
+played.
+
+There is a massive https://doomwiki.org/wiki/Idgames_archive[back
+catalog], spanning over two decades, containing thousands of _Doom_
+levels and other modifications (“mods”) made by fans of the game.
+_Freedoom_ aims to be compatible with these and allows most to be
+played without the need to use non-free software.
+
+_Freedoom_ is actually three games in one, consisting of two
+single-player oriented campaigns and one set of levels designed
+exclusively for multiplayer deathmatch:
+
+[horizontal]
+*Freedoom: Phase 1*:: Four episodes, nine levels each, totalling 36
+levels.  This game aims for compatibility with _The Ultimate Doom_
+mods, also known as plain _Doom_ or _Doom 1_.
+*Freedoom: Phase 2*:: 32 levels in one long episode, featuring extra
+monsters and a double-barrelled shotgun.  This project aims for
+compatibility with _Doom II_ mods.
+*FreeDM*:: A 32-level game designed for competitive deathmatch play.
+
+The engine uses a single file, such as +freedoom2.wad+, that contains
+all the game data such as graphics, sound effects, music, and so on.
+This file is often called an “IWAD” by those in the _Doom_ and
+_Freedoom_ communities.  While the _Doom_ engine source code is free,
+you would normally still need one of the proprietary data files from
+https://www.idsoftware.com/[id Software] to play _Doom_.  _Freedoom_
+aims to create a free alternative: combined with the GPL-licensed
+_Doom_ source code, this results in a completely free game.
+
+For more information, see https://freedoom.github.io/.
+
+== How to play
+
+Since _Freedoom_ is only the game data, you will still need to
+download an engine separately.  These are also often termed “source
+ports” by the community.  There are an overwhelming number of choices
+available, a lengthy list of which is available on the
+https://doomwiki.org/wiki/Source_port[Doom Wiki].
+
+One particularly recommended by the _Freedoom_ project is
+https://zdoom.org/[GZDoom].  This engine offers good support for
+single-player, multi-player, and the majority of mods created for both
+_Doom_ and _Freedoom_.
+
+On Windows, you should place _Freedoom_’s data files (those ending
+with +.wad+) alongside the engine (eg, +odamex.exe+).  On Unix-like
+systems, these data files should go in either +/usr/share/games/doom+
+or your home directory.  If _Freedoom_ comes packaged as part of your
+operating system distribution, it should already be installed into the
+proper location.
+
+Hopefully, your engine of choice should already be capable of running
+_Freedoom_ without extra configuration.  This may not be the case,
+however, if the engine does not recognize any of the filenames for
+_Freedoom_, and might require manual intervention to make it so.  One
+of the following options should solve it:
+
+  * Use the +-iwad+ command line parameter.  For example, to play
+    Phase 2, you can enter +-iwad freedoom2.wad+ either at a command
+    line, or adding it to an application shortcut.
+  * Use the +DOOMWADPATH+ environment variable.  Many engines support
+    this variable to add directories and/or files to their search
+    path.  The exact syntax matches your operating system’s normal
+    +PATH+ environment variable.
+  * Rename the game files.  This may be a bit crude, but you can
+    rename the files to match those of _Doom_’s.  This is often the
+    easiest quick-fix, although it is normally desirable to use one of
+    the above methods if possible.
+
+    ** +freedoom1.wad+ can be renamed to +doom.wad+
+    ** +freedoom2.wad+ can be renamed to +doom2.wad+
+    ** +freedm.wad+ can be renamed to +doom2.wad+
+
+Additionally, for Unix-like operating systems, such as GNU/Linux or a
+BSD variant, _Freedoom_ may be packaged and installed with programs
+named +freedoom1+, +freedoom2+, and +freedm+ that automatically run an
+engine for proper play.  Desktop files may also be installed so that
+you can start the game using a graphical interface and avoid the
+command line altogether.
+
+== What “free” means
+
+When we speak of free content or software, we refer to the movement in
+which your freedoms to use, copy, modify, and study a work is not
+infringed.  For example, you may freely use _Freedoom_ for any purpose
+you see fit, you may redistribute it to anyone without needing to ask
+for permission, you may modify it (provided you keep the license
+intact, see `COPYING`), and you may study it--for example, to see how
+an “IWAD” is built.  To facilitate this, you can get the full source
+code for _Freedoom_, in this case, in the form of a DeuTex tree.
+
+You may read more about free software at the https://www.gnu.org/[GNU]
+and https://www.fsf.org/[Free Software Foundation] websites.
+
+== Contributing to Freedoom
+
+Contributions to _Freedoom_ are always welcome, however there are a
+few guidelines that should be followed:
+
+=== Intellectual property
+
+We know people hate legalese, but this is important.  This applies to
+*everything* which is submitted.
+
+You must be careful when basing on existing graphics or sounds.  Most
+_Doom_ projects are lax on reusing intellectual property--there are
+many mods which contain modified _Doom_ sprites, for example.
+However, due to the nature of this project, we do not have the same
+liberty to rip as we please.
+
+The general rules go as follows:
+
+  * You must have permission for everything you submit.  If you make
+    your own resources, do not base on resources from _Doom_ or any
+    other restricted work.  If you take work from other places, please
+    make sure that the work is freely-licensed or that you obtain
+    permission to include it in the _Freedoom_ project.  They may not
+    place additional restrictions compared to the normal _Freedoom_
+    license.
+  * Do not try to emulate _Doom_ resources exactly.  Where possible,
+    put effort to make new versions look visibly different from
+    _Doom_.  This is a tough call, because our compatibility with
+    _Doom_ mods limits how far we can deviate, but it is feasible.
+  * Be especially careful of “free textures” (or “free sounds” or
+    “free graphics”) sites.  Although these would appear at first to
+    be okay to use, many are free for “non-commercial use only.”
+    One of the things we want to be able to do is put this in
+    GNU/Linux distributions (which can be sold or developed
+    commercially).
+
+=== Levels
+
+All levels for _Freedoom_ must be vanilla-compatible, requiring an
+expanded-limits or limit-removing engine is not permissible.  This
+means you may not exceed the limits of the original _Doom_ engine, and
+do not depend on additional mapping features.  Levels should be in
+_Doom_’s original format, not in “Hexen”-format.
+
+It is sensible to also heed the following guidelines:
+
+  * Make sure that skill levels are implemented, and that all
+    multiplayer start points, both cooperative and deathmatch, are
+    present.
+  * Try to make levels appropriately difficult for their position
+    within the progression of the game.  Also bear in mind that not
+    all players may be as skilled a player as you.
+  * Do not use tricks that exploit _Doom_’s software renderer; some
+    engines, especially those that use hardware accelerated rendering,
+    may not render it properly.  Examples of tricks to avoid include
+    those used to simulate 3D bridges and “deep water” effects.
+  * While unrestricted by limits, do not make excessively complicated
+    scenes.  It is desirable that _Freedoom_ levels should be playable
+    on low-powered hardware, such as phones and old computers.
+  * Test your levels in https://www.chocolate-doom.org/[Chocolate
+    Doom] to make sure that vanilla compatibility is maintained.  This
+    is an engine with strict adherence to vanilla Doom limits and
+    bugs, and working in it assures that levels can be played with any
+    _Doom_ engine.
+  * Use a Doom editor to check for errors. In
+    http://eureka-editor.sourceforge.net/[Eureka] it's possible to
+    check for errors with the Check / All menu, or by pressing `F9`.
+  * If possible run `make test` and fix any errors found. Note that
+    some of the errors can be fixed by `make fix`.
+
+=== Graphics
+
+Graphics should generally have the same color and size as the original
+_Doom_ graphics, as to remain compatible with mods.  Otherwise, levels
+may end up looking like a nightmare in design.  They may be
+thematically different as long as it doesn’t clash.
+
+_Doom_ uses a fictional corporation abbreviated as “UAC:” this is
+trademarked by id Software and cannot be used in _Freedoom_.  Instead,
+use the initials “AGM” for _Freedoom_.
+
+=== Documentation
+
+_Freedoom_ always needs help with documentation, so please send your
+patches, but keep in mind:
+
+  * We use http://asciidoc.org/[AsciiDoc] for writing the
+    documentation.  AsciiDoc is a simple plaintext-based format which
+    is simple to read and write in its source form, and can generate
+    nice HTML documents out of them.
+  * Headers are formated in a wiki-style format, this makes it easier
+    for Vim (perhaps other editors, too) to automatically re-format
+    text.
+  * Text is kept at 72 characters wide.  In Vim, you can set the
+    editor to automatically insert line breaks as you’re typing by
+    performing `set textwidth=72`.  Special exceptions to the width
+    rule might be allowed when necessary (for example, inserting long
+    URLs).
+
+=== Submitting your work
+
+The most common, and a fairly simple method, to submit your work is by
+posting it on the
+https://www.doomworld.com/forum/17-freedoom/[Freedoom forum] on
+Doomworld Forums.  This allows a great number of people to review the
+contribution and provide feedback, although the registration process
+is known to be cumbersome.
+
+An alternative to using the forum, is to post your submission on the
+https://github.com/freedoom/freedoom/issues[issue tracker], which may
+also be peer-reviewed and provide a feedback cycle.
+
+Unfortunately, the Freedoom project cannot provide hosting space in
+the form of a web page nor FTP, however there are many free file hosts
+to use when you need a location to upload files.  Sites and services
+such as https://www.dropbox.com/[Dropbox] and
+https://mega.co.nz/[Mega], as well as others, are common and should be
+simple to use.
+
+==== Crediting information
+
+_Freedoom_ is made up of submissions from many people all over the
+globe.  All of them, and you, deserve credit!  Please do not forget to
+provide your name and email when submitting resources.
+
+==== Using Git
+
+You can also commit on a clone of the _Freedoom_ repository, although
+this is a technical task and it is okay to let other _Freedoom_
+maintainers to do it instead: that is our normal mode of operation.
+However, pull requests are much appreciated and you may submit them in
+any manner you wish, with GitHub’s direct pull requests being the
+simplest, but by far not the only means.
+
+Freedoom uses the commit message style commonly seen in distributed
+version control systems, adopted by projects such as Linux and Git.
+For an explanation of this style, see
+https://chris.beams.io/posts/git-commit/[How to Write a Git Commit
+Message].
+
+If you create a git commit for someone else it is helpful to set the
+author of the commit so that they get credit. Ask them what name/alias
+and email they would like to use. For example:
+[source,bash]
+-----------------
+git commit --author "Bob Smith <bob@example.com>" ...
+-----------------
+If they prefer not to give an email then the email can be omitted, so
+just "Bob Smith" in the above example.


### PR DESCRIPTION
dist/ contains metadata for displaying information about Blasphemer in various GNU/Linux distributions. For now, this is useless without edits to the build system, but will come in handy for creating packages for software repositories.
In the docs I have added the Freedoom license and credits, as is done in LibreQuake, to make sure that all authors are given credit, given that Blasphemer uses many resources and some levels from Freedoom. 